### PR TITLE
JS reorg & add mode option dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,858 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.2.tgz",
+      "integrity": "sha512-IFeSSnjXdhDaoysIlev//UzHZbdEmm7D0EIH2qtse9xK7mXEZQpYjs2P00XlP1qYsYvid79p+Zgg6tz1mp6iVw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.1.2",
+        "@babel/helpers": "^7.1.2",
+        "@babel/parser": "^7.1.2",
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.1.2",
+        "convert-source-map": "^1.1.0",
+        "debug": "^3.1.0",
+        "json5": "^0.5.0",
+        "lodash": "^4.17.10",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.3.tgz",
+      "integrity": "sha512-ZoCZGcfIJFJuZBqxcY9OjC1KW2lWK64qrX1o4UYL3yshVhwKFYgzpWZ0vvtGMNJdTlvkw0W+HR1VnYN8q3QPFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.1.3",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
+      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.1.0.tgz",
+      "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-call-delegate": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
+      "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
+      "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.1.0.tgz",
+      "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
+      "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz",
+      "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
+      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.1.0.tgz",
+      "integrity": "sha512-0JZRd2yhawo79Rcm4w0LwSMILFmFXjugG3yqf+P/UsKsRS1mJCmMwwlHDlMg7Avr9LrvSpp4ZSULO9r8jpCzcw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
+      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
+      "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-wrap-function": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.1.0.tgz",
+      "integrity": "sha512-BvcDWYZRWVuDeXTYZWxekQNO5D4kO55aArwZOTFXw6rlLQA8ZaDicJR1sO47h+HrnCiDFiww0fSPV0d713KBGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
+      "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.1.0.tgz",
+      "integrity": "sha512-R6HU3dete+rwsdAfrOzTlE9Mcpk4RjU3aX3gi9grtmugQY0u79X7eogUvfXA5sI81Mfq1cn6AgxihfN33STjJA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/template": "^7.1.0",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.1.2.tgz",
+      "integrity": "sha512-Myc3pUE8eswD73aWcartxB16K6CGmHDv9KxOmD2CeOs/FaEAQodr3VYGmlvOmog60vNQ2w8QbatuahepZwrHiA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.1.2",
+        "@babel/traverse": "^7.1.0",
+        "@babel/types": "^7.1.2"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.3.tgz",
+      "integrity": "sha512-gqmspPZOMW3MIRb9HlrnbZHXI1/KHTOroBwN1NcLL6pWxzqzEKGvRTq0W/PxS45OtQGbaFikSQpkS5zbnsQm2w==",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.1.0.tgz",
+      "integrity": "sha512-Fq803F3Jcxo20MXUSDdmZZXrPe6BWyGcWBPPNB/M7WaUYESKDeKMOGIxEzQOjGSmW/NWb6UaPZrtTB2ekhB/ew==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz",
+      "integrity": "sha512-kfVdUkIAGJIVmHmtS/40i/fg/AGnw/rsZBCaapY5yjeO5RA9m165Xbw9KMOu2nqXP5dTFjEjHdfNdoVcHv133Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-json-strings": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0.tgz",
+      "integrity": "sha512-14fhfoPcNu7itSen7Py1iGN0gEm87hX/B+8nZPqkdmANyyYWYMY2pjA3r8WXbWVKMzfnSNS0xY8GVS0IjXi/iw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.0.0.tgz",
+      "integrity": "sha512-JPqAvLG1s13B/AuoBjdBYvn38RqW6n1TzrQO839/sIpqLpbnXKacsAgpZHzLD83Sm8SDXMkkrAvEnJ25+0yIpw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.0.0.tgz",
+      "integrity": "sha512-tM3icA6GhC3ch2SkmSxv7J/hCWKISzwycub6eGsDrFDgukD4dZ/I+x81XgW0YslS6mzNuQ1Cbzh5osjIMgepPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.2.0"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+          "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.4.0",
+            "regjsparser": "^0.3.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz",
+      "integrity": "sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz",
+      "integrity": "sha512-UlSfNydC+XLj4bw7ijpldc1uZ/HB84vw+U6BTuqMdIEmz/LDe63w/GHtpQMdXWdqQZFeAI9PjnHe/vDhwirhKA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.0.0.tgz",
+      "integrity": "sha512-5A0n4p6bIiVe5OvQPxBnesezsgFJdHhSs3uFSvaPdMqtsovajLZ+G2vZyvNe10EzJBWWo3AcHGKhAFUxqwp2dw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz",
+      "integrity": "sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz",
+      "integrity": "sha512-2EZDBl1WIO/q4DIkIp4s86sdp4ZifL51MoIviLY/gG/mLSuOIEg7J8o6mhbxOTvUJkaN50n+8u41FVsr5KLy/w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.1.0.tgz",
+      "integrity": "sha512-rNmcmoQ78IrvNCIt/R9U+cixUHeYAzgusTFgIAv+wQb9HJU4szhpDD6e5GCACmj/JP5KxuCwM96bX3L9v4ZN/g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-remap-async-to-generator": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0.tgz",
+      "integrity": "sha512-AOBiyUp7vYTqz2Jibe1UaAWL0Hl9JUXEgjFvvvcSc9MVDItv46ViXFw2F7SVt1B5k+KWjl44eeXOAk3UDEaJjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0.tgz",
+      "integrity": "sha512-GWEMCrmHQcYWISilUrk9GDqH4enf3UmhOEbNbNrlNAX1ssH3MsS1xLOS6rdjRVPgA7XXVPn87tRkdTEoA/dxEg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "lodash": "^4.17.10"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.1.0.tgz",
+      "integrity": "sha512-rNaqoD+4OCBZjM7VaskladgqnZ1LO6o2UxuWSDzljzW21pN1KXkB7BstAVweZdxQkHAujps5QMNOTWesBciKFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-define-map": "^7.1.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0.tgz",
+      "integrity": "sha512-ubouZdChNAv4AAWAgU7QKbB93NU5sHwInEWfp+/OzJKA02E6Woh9RVoX4sZrbRwtybky/d7baTUqwFx+HgbvMA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.1.3.tgz",
+      "integrity": "sha512-Mb9M4DGIOspH1ExHOUnn2UUXFOyVTiX84fXCd+6B5iWrQg/QMeeRmSwpZ9lnjYLSXtZwiw80ytVMr3zue0ucYw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.0.0.tgz",
+      "integrity": "sha512-00THs8eJxOJUFVx1w8i1MBF4XH4PsAjKjQ1eqN/uCH3YKwP21GCKfrn6YZFZswbOk9+0cw1zGQPHVc1KBlSxig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+          "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.4.0",
+            "regjsparser": "^0.3.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0.tgz",
+      "integrity": "sha512-w2vfPkMqRkdxx+C71ATLJG30PpwtTpW7DDdLqYt2acXU7YjztzeWW2Jk1T6hKqCLYCcEA5UQM/+xTAm+QCSnuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.1.0.tgz",
+      "integrity": "sha512-uZt9kD1Pp/JubkukOGQml9tqAeI8NkE98oZnHZ2qHRElmeKCodbTZgOEUtujSCSLhHSBWbzNiFSDIMC4/RBTLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0.tgz",
+      "integrity": "sha512-TlxKecN20X2tt2UEr2LNE6aqA0oPeMT1Y3cgz8k4Dn1j5ObT8M3nl9aA37LLklx0PBZKETC9ZAf9n/6SujTuXA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.1.0.tgz",
+      "integrity": "sha512-VxOa1TMlFMtqPW2IDYZQaHsFrq/dDoIjgN098NowhexhZcz3UGlvPgZXuE1jEvNygyWyxRacqDpCZt+par1FNg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0.tgz",
+      "integrity": "sha512-1NTDBWkeNXgpUcyoVFxbr9hS57EpZYXpje92zv0SUzjdu3enaRwF/l3cmyRnXLtIdyJASyiS6PtybK+CgKf7jA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.1.0.tgz",
+      "integrity": "sha512-wt8P+xQ85rrnGNr2x1iV3DW32W8zrB6ctuBkYBbf5/ZzJY99Ob4MFgsZDFgczNU76iy9PWsy4EuxOliDjdKw6A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
+      "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-simple-access": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.1.3.tgz",
+      "integrity": "sha512-PvTxgjxQAq4pvVUZF3mD5gEtVDuId8NtWkJsZLEJZMZAW3TvgQl1pmydLLN1bM8huHFVVU43lf0uvjQj9FRkKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.1.0.tgz",
+      "integrity": "sha512-enrRtn5TfRhMmbRwm7F8qOj0qEYByqUvTttPEGimcBH4CJHphjyK1Vg7sdU7JjeEmgSpM890IT/efS2nMHwYig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.1.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
+      "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.1.0.tgz",
+      "integrity": "sha512-/O02Je1CRTSk2SSJaq0xjwQ8hG4zhZGNjE8psTsSNPXyLRCODv7/PBozqT5AmQMzp7MI3ndvMhGdqp9c96tTEw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.1.0"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.1.0.tgz",
+      "integrity": "sha512-vHV7oxkEJ8IHxTfRr3hNGzV446GAb+0hgbA7o/0Jd76s+YzccdWuTU296FOCOl/xweU4t/Ya4g41yWz80RFCRw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-call-delegate": "^7.1.0",
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0.tgz",
+      "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.13.3"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0.tgz",
+      "integrity": "sha512-g/99LI4vm5iOf5r1Gdxq5Xmu91zvjhEG5+yZDJW268AZELAu4J1EiFLnkSG3yuUsZyOipVOVUKoGPYwfsTymhw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0.tgz",
+      "integrity": "sha512-L702YFy2EvirrR4shTj0g2xQp7aNwZoWNCkNu2mcoU0uyzMl0XRwDSwzB/xp6DSUFiBmEXuyAyEN16LsgVqGGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz",
+      "integrity": "sha512-LFUToxiyS/WD+XEWpkx/XJBrUXKewSZpzX68s+yEOtIbdnsRjpryDw9U06gYc6klYEij/+KQVRnD3nz3AoKmjw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0.tgz",
+      "integrity": "sha512-vA6rkTCabRZu7Nbl9DfLZE1imj4tzdWcg5vtdQGvj+OH9itNNB6hxuRMHuIY8SGnEt1T9g5foqs9LnrHzsqEFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0.tgz",
+      "integrity": "sha512-1r1X5DO78WnaAIvs5uC48t41LLckxsYklJrZjNKcevyz83sF2l4RHbw29qrCPr/6ksFsdfRpT/ZgxNWHXRnffg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz",
+      "integrity": "sha512-uJBrJhBOEa3D033P95nPHu3nbFwFE9ZgXsfEitzoIXIwqAZWk7uXcg06yFKXz9FSxBH5ucgU/cYdX0IV8ldHKw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-regex": "^7.0.0",
+        "regexpu-core": "^4.1.3"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
+          "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.4.0",
+            "regenerate-unicode-properties": "^7.0.0",
+            "regjsgen": "^0.4.0",
+            "regjsparser": "^0.3.0",
+            "unicode-match-property-ecmascript": "^1.0.4",
+            "unicode-match-property-value-ecmascript": "^1.0.2"
+          }
+        },
+        "regjsgen": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
+          "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA==",
+          "dev": true
+        },
+        "regjsparser": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
+          "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
+          "dev": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        }
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.0.tgz",
+      "integrity": "sha512-ZLVSynfAoDHB/34A17/JCZbyrzbQj59QC1Anyueb4Bwjh373nVPq5/HMph0z+tCmcDjXDe+DlKQq9ywQuvWrQg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.1.0",
+        "@babel/plugin-proposal-json-strings": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.0.0",
+        "@babel/plugin-syntax-async-generators": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-async-to-generator": "^7.1.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.1.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-dotall-regex": "^7.0.0",
+        "@babel/plugin-transform-duplicate-keys": "^7.0.0",
+        "@babel/plugin-transform-exponentiation-operator": "^7.1.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.1.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-amd": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.0.0",
+        "@babel/plugin-transform-modules-umd": "^7.1.0",
+        "@babel/plugin-transform-new-target": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.1.0",
+        "@babel/plugin-transform-parameters": "^7.1.0",
+        "@babel/plugin-transform-regenerator": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-sticky-regex": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "@babel/plugin-transform-typeof-symbol": "^7.0.0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0",
+        "browserslist": "^4.1.0",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.3.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
+      "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.1.2",
+        "@babel/types": "^7.1.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.4.tgz",
+      "integrity": "sha512-my9mdrAIGdDiSVBuMjpn/oXYpva0/EZwWL3sm3Wcy/AVWO2eXnsoZruOT9jOGNRXU8KbCIu5zsKnXcAJ6PcV6Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.1.3",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.1.3",
+        "@babel/types": "^7.1.3",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
+      "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@mapbox/extent": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@mapbox/extent/-/extent-0.4.0.tgz",
@@ -579,6 +1431,18 @@
         }
       }
     },
+    "babel-loader": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.4.tgz",
+      "integrity": "sha512-fhBhNkUToJcW9nV46v8w87AJOwAJDz84c1CL57n3Stj73FANM/b9TbCUK4YhdOwEyZ+OxhYpdeZDNzSI29Firw==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "util.promisify": "^1.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -846,6 +1710,17 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.4.tgz",
+      "integrity": "sha512-u5iz+ijIMUlmV8blX82VGFrB9ecnUg5qEt55CMZ/YJEhha+d8qpBfOFuutJ6F/VKRXjZoD33b6uvarpPxcl3RA==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000899",
+        "electron-to-chromium": "^1.3.82",
+        "node-releases": "^1.0.1"
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -949,6 +1824,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000903",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz",
+      "integrity": "sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==",
       "dev": true
     },
     "cardinal": {
@@ -1925,6 +2806,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
+      "integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA==",
       "dev": true
     },
     "elliptic": {
@@ -3242,6 +4129,12 @@
       "integrity": "sha512-HchvMJNYh9dGSCy8pOQ2O8u/hoXaL+0XhnrwH0RyLiSXMMTl9W3N6KUU73+JFOg5PGjtzl6VZzUQsnrpm7Szag==",
       "dev": true
     },
+    "globals": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
+      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "dev": true
+    },
     "globby": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -3833,6 +4726,15 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -4110,6 +5012,12 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
+    "js-levenshtein": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
+      "integrity": "sha512-PxfGzSs0ztShKrUYPIn5r0MtyAhYcCwmndozzpz8YObbPnD1jFxzlBGbRnX2mIu6Z13xN6+PTu05TQFnZFlzow==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -4256,6 +5164,15 @@
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
       "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -4678,6 +5595,15 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
+      }
+    },
+    "node-releases": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.2.tgz",
+      "integrity": "sha512-zP8Asfg13lG9KDAW85rylSxXBYvaSdtjMIYKHUk8c1fM8drmFwRqbSYKYD+UlNVPUvrceSvgLUKHMOWR5jPWQg==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.3.0"
       }
     },
     "nomnom": {
@@ -5216,11 +6142,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
-    "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg=="
-    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
@@ -5271,6 +6192,12 @@
           }
         }
       }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",
@@ -5496,6 +6423,24 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
+      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-transform": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",
+      "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
+      "dev": true,
+      "requires": {
+        "private": "^0.1.6"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -6434,6 +7379,12 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -6486,6 +7437,12 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",
@@ -6568,6 +7525,34 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "homepage": "https://github.com/cityofaustin/dockless#readme",
   "devDependencies": {
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "babel-loader": "^8.0.4",
     "clean-webpack-plugin": "^0.1.19",
     "css-loader": "^1.0.1",
     "file-loader": "^2.0.0",

--- a/src/index.html
+++ b/src/index.html
@@ -24,17 +24,27 @@
               </p>
             </div>
           </div>
-          <div class="row">
-            <div class="col-lg-12">
-              <form class="form-inline" id="flowSelector" action="#">
-                <label for="uom">Flow</label>
-                <select class="form-control ml-2" id="uom">
-                  <option value="origin">Origin</option>
-                  <option value="destination">Destination</option>
-                </select>
-              </form>
-            </div>
-          </div>
+            <form id="flowSelector" action="#">
+              <div class="form-group row">
+                <label for="uom" class="col-sm-3 col-form-label">Flow</label>
+                <div class="col-sm-9">
+                  <select class="form-control" id="uom">
+                    <option value="origin">Origin</option>
+                    <option value="destination">Destination</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group row">
+                <label for="mode" class="col-sm-3 col-form-label">Mode</label>
+                <div class="col-sm-9">
+                  <select class="form-control" id="mode">
+                    <option value="all">All</option>
+                    <option value="scooter">Scooter</option>
+                    <option value="bicycle">Bicycle</option>
+                  </select>
+                </div>
+              </div>
+            </form>
           <div class="col align-self-center pt-2" id="dataPane">
               <!-- <p class="loader">Loading...</p> -->
           </div>

--- a/src/index.html
+++ b/src/index.html
@@ -24,20 +24,20 @@
               </p>
             </div>
           </div>
-            <form id="flowSelector" action="#">
+            <form id="data-select-form" action="#">
               <div class="form-group row">
-                <label for="uom" class="col-sm-3 col-form-label">Flow</label>
+                <label for="flow-select" class="col-sm-3 col-form-label">Flow</label>
                 <div class="col-sm-9">
-                  <select class="form-control" id="uom">
+                  <select class="form-control js-flow-select" id="flow-select">
                     <option value="origin">Origin</option>
                     <option value="destination">Destination</option>
                   </select>
                 </div>
               </div>
               <div class="form-group row">
-                <label for="mode" class="col-sm-3 col-form-label">Mode</label>
+                <label for="mode-select" class="col-sm-3 col-form-label">Mode</label>
                 <div class="col-sm-9">
-                  <select class="form-control" id="mode">
+                  <select class="form-control js-mode-select" id="mode-select">
                     <option value="all">All</option>
                     <option value="scooter">Scooter</option>
                     <option value="bicycle">Bicycle</option>
@@ -46,7 +46,6 @@
               </div>
             </form>
           <div class="col align-self-center pt-2" id="dataPane">
-              <!-- <p class="loader">Loading...</p> -->
           </div>
         </div>
       </div>

--- a/src/index.html
+++ b/src/index.html
@@ -51,7 +51,5 @@
         </div>
       </div>
     </div>
-    <script src="./app.bundle.js"></script>
-
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -30,30 +30,19 @@ const ATD_DocklessMap = (function() {
     this.$ui = $("#js");
 
     setHeight("#map-container");
+    initalizeMap();
     runAppCode();
     registerEventHandlers();
   };
 
-  // TODO: Break this down into smaller pieces
-  const runAppCode = () => {
-    var formatPct = format(".1%");
-    var formatKs = format(",");
-
-    var total_trips;
-    var data;
-    var flow;
-    var first = true;
-
+  const initalizeMap = () => {
     docklessMap.API_URL = "http://localhost:8000/v1/trips";
     mapboxgl.accessToken =
       "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqbjhkZ25vcjF2eTMzbG52dGRlbnVqOHAifQ.y1xhnHxbB6KlpQgTp1g1Ow";
     docklessMap.map = new mapboxgl.Map(docklessMap.mapOptions);
 
-    // map = new mapboxgl.Map(docklessMap.mapOptions);
-
     // add nav
     var nav = new mapboxgl.NavigationControl();
-
     docklessMap.map.addControl(nav, "top-left");
 
     // add drawing
@@ -65,10 +54,19 @@ const ATD_DocklessMap = (function() {
         uncombine_features: false
       }
     };
+    docklessMap.Draw = new MapboxDraw(drawOptions);
+    docklessMap.map.addControl(docklessMap.Draw, "top-left");
+  };
 
-    var Draw = new MapboxDraw(drawOptions);
+  // TODO: Break this down into smaller pieces
+  const runAppCode = () => {
+    var formatPct = format(".1%");
+    var formatKs = format(",");
 
-    docklessMap.map.addControl(Draw, "top-left");
+    var total_trips;
+    var data;
+    var flow;
+    var first = true;
 
     // do magic
     docklessMap.map.on("load", function() {
@@ -203,7 +201,7 @@ const ATD_DocklessMap = (function() {
 
     function getData(url) {
       json(url).then(function(json) {
-        Draw.deleteAll();
+        docklessMap.Draw.deleteAll();
         total_trips = json.total_trips;
         addFeatures(json.features, json.intersect_feature, json.total_trips);
       });

--- a/src/index.js
+++ b/src/index.js
@@ -9,26 +9,56 @@ import { ckmeans } from "simple-statistics";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 import "./style.css";
 
-var map = {
-  init: function() {
+// Locally Scoped Object Module Pattern
+// more info: https://toddmotto.com/mastering-the-module-pattern/#locally-scoped-object-literal
+const ATD_DocklessMap = (function() {
+  // We let this empty object be the placeholder to attach public methods.
+  let docklessMap = {};
+
+  // We attach public methods like this using object literal notation.
+  docklessMap.init = function() {
     console.log("initializing");
     this.options = {
       test: "mapfoo"
     };
     this.$ui = $("#js");
-    this.registerEventHandlers();
-    this.setHeight("#map-container");
-  },
-  registerEventHandlers: function() {
+    registerEventHandlers();
+    setHeight("#map-container");
+  };
+
+  // All methods declared with `const`, must be "private" and are scoped
+  const registerEventHandlers = () => {
     console.log("register events");
-  },
-  setHeight: function(selector) {
+    clearMapOnEscEvent();
+  };
+
+  const setHeight = selector => {
     var height = $(window).height();
     $(selector).css("height", height);
-  }
-};
+  };
 
-map.init();
+  const clearMapOnEscEvent = () => {
+    $(document).keyup(function(e) {
+      if (e.keyCode === 27) {
+        showLayer("feature_layer", false);
+        showLayer("reference_layer", false);
+        removeStats();
+      }
+    });
+  };
+
+  const showLayer = function(layer_name, show_layer) {
+    if (!show_layer) {
+      map.setLayoutProperty(layer_name, "visibility", "none");
+    } else {
+      map.setLayoutProperty(layer_name, "visibility", "visible");
+    }
+  };
+
+  return docklessMap;
+})();
+
+ATD_DocklessMap.init();
 
 // var API_URL = 'https://dockless-data.austintexas.io/api'
 var API_URL = "http://localhost:8000/v1/trips";
@@ -40,15 +70,6 @@ var total_trips;
 var data;
 var flow;
 var first = true;
-
-// clear map on ESC key press
-$(document).keyup(function(e) {
-  if (e.keyCode === 27) {
-    showLayer("feature_layer", false);
-    showLayer("reference_layer", false);
-    removeStats();
-  }
-});
 
 mapboxgl.accessToken =
   "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqbjhkZ25vcjF2eTMzbG52dGRlbnVqOHAifQ.y1xhnHxbB6KlpQgTp1g1Ow";
@@ -241,6 +262,7 @@ function postCellTripCount(feature, divId = "dataPane") {
   $("#dataPane").append(html);
 }
 
+// todo, move other showLayer calls into module
 const showLayer = (layer_name, show_layer) => {
   if (!show_layer) {
     map.setLayoutProperty(layer_name, "visibility", "none");

--- a/src/index.js
+++ b/src/index.js
@@ -23,21 +23,25 @@ const ATD_DocklessMap = (function() {
     };
     this.$ui = $("#js");
     registerEventHandlers();
+    runAppCode();
+  };
+
+  // TODO: Break this down into smaller pieces
+  const runAppCode = () => {
     setHeight("#map-container");
-  };
 
-  // All methods declared with `const`, must be "private" and are scoped
-  const registerEventHandlers = () => {
-    console.log("register events");
-    clearMapOnEscEvent();
-  };
+    // var API_URL = 'https://dockless-data.austintexas.io/api'
+    var API_URL = "http://localhost:8000/v1/trips";
 
-  const setHeight = selector => {
-    var height = $(window).height();
-    $(selector).css("height", height);
-  };
+    var formatPct = format(".1%");
+    var formatKs = format(",");
 
-  const clearMapOnEscEvent = () => {
+    var total_trips;
+    var data;
+    var flow;
+    var first = true;
+
+    // clear map on ESC key press
     $(document).keyup(function(e) {
       if (e.keyCode === 27) {
         showLayer("feature_layer", false);
@@ -45,284 +49,278 @@ const ATD_DocklessMap = (function() {
         removeStats();
       }
     });
+
+    mapboxgl.accessToken =
+      "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqbjhkZ25vcjF2eTMzbG52dGRlbnVqOHAifQ.y1xhnHxbB6KlpQgTp1g1Ow";
+
+    var mapOptions = {
+      container: "map",
+      style: "mapbox://styles/mapbox/light-v9",
+      center: [-97.74, 30.275],
+      zoom: 13,
+      minZoom: 1,
+      maxZoom: 19
+    };
+
+    // init map
+    var map = new mapboxgl.Map(mapOptions);
+
+    // add nav
+    var nav = new mapboxgl.NavigationControl();
+
+    map.addControl(nav, "top-left");
+
+    // add drawing
+    var drawOptions = {
+      controls: {
+        trash: false,
+        line_string: false,
+        combine_features: false,
+        uncombine_features: false
+      }
+    };
+
+    var Draw = new MapboxDraw(drawOptions);
+
+    map.addControl(Draw, "top-left");
+
+    // do magic
+    map.on("load", function() {
+      var url;
+
+      flow = $("#flowSelector option:selected").val();
+
+      $("#flowSelector").change(function() {
+        var previousFlow = flow;
+
+        flow = $("#flowSelector option:selected").val();
+
+        if (map.getLayer("feature_layer")) {
+          var visibility = map.getLayoutProperty("feature_layer", "visibility");
+
+          // if showing feature layer, update layer with new flow
+          if (visibility === "visible") {
+            url = url.replace(previousFlow, flow);
+            showLoader();
+            getData(url);
+            removeStats();
+          }
+        }
+      });
+
+      map.on("draw.create", function(e) {
+        showLoader();
+        url = getUrl(e.features, flow);
+        console.log(url);
+        getData(url);
+        removeStats();
+      });
+
+      map.on("draw.update", function(e) {
+        showLoader();
+        url = getUrl(e.features, flow);
+        getData(url);
+        removeStats();
+      });
+
+      map.on("click", "feature_layer", function(e) {
+        postCellTripCount(e.features[0]);
+      });
+
+      // Change the cursor to a pointer when the mouse is over the states layer.
+      map.on("mouseenter", "feature_layer", function() {
+        map.getCanvas().style.cursor = "pointer";
+      });
+
+      // Change it back to a pointer when it leaves.
+      map.on("mouseleave", "feature_layer", function() {
+        map.getCanvas().style.cursor = "";
+      });
+
+      function getUrl(features, flow) {
+        var coordinates = features[0].geometry.coordinates.toString();
+
+        var url = API_URL + "?xy=" + coordinates + "&flow=" + flow;
+        return url;
+      }
+    });
+
+    function addFeatures(features, reference_features, total_trips) {
+      if (first) {
+        map.addLayer({
+          id: "feature_layer",
+          type: "fill-extrusion",
+          source: {
+            type: "geojson",
+            data: features
+          },
+          layout: {},
+          paint: {
+            "fill-extrusion-color": getPaint(features.features),
+
+            "fill-extrusion-height": [
+              "*",
+              ["number", ["get", "current_count"]],
+              1
+            ],
+            "fill-extrusion-base": 0,
+            "fill-extrusion-opacity": 0.7
+          }
+        });
+
+        map.addLayer({
+          id: "reference_layer",
+          type: "line",
+          source: {
+            type: "geojson",
+            data: reference_features
+          },
+          layout: {
+            "line-cap": "round",
+            "line-join": "round"
+          },
+          paint: {
+            "line-color": "#000",
+            "line-opacity": 0.4,
+            "line-width": 3,
+            "line-dasharray": [3, 3]
+          }
+        });
+
+        showLayer("feature_layer", true);
+        showLayer("reference_layer", true);
+        hideLoader();
+        postTrips(total_trips);
+        first = false;
+      } else {
+        updateLayers(features, reference_features, total_trips);
+      }
+    }
+
+    function updateLayers(features, reference_features, total_trips) {
+      map.getSource("reference_layer").setData(reference_features);
+      map.getSource("feature_layer").setData(features);
+      map.setPaintProperty(
+        "feature_layer",
+        "fill-extrusion-color",
+        getPaint(features.features)
+      );
+      showLayer("feature_layer", true);
+      showLayer("reference_layer", true);
+      hideLoader();
+      postTrips(total_trips);
+    }
+
+    function getData(url) {
+      json(url).then(function(json) {
+        Draw.deleteAll();
+        total_trips = json.total_trips;
+        addFeatures(json.features, json.intersect_feature, json.total_trips);
+      });
+    }
+
+    function postCellTripCount(feature, divId = "dataPane") {
+      var trip_percent = feature.properties.current_count / total_trips;
+
+      if (flow == "origin") {
+        var text =
+          formatKs(feature.properties.current_count) +
+          " (" +
+          formatPct(trip_percent) +
+          ") trips originated in the clicked cell.";
+      } else if (flow == "destination") {
+        var text =
+          formatKs(feature.properties.current_count) +
+          " (" +
+          formatPct(trip_percent) +
+          ") trips terminated in the clicked cell.";
+      }
+
+      var html =
+        '<div id="cellTripCount" class="alert alert-dark stats" role="alert">' +
+        text +
+        "</div>";
+
+      $("#cellTripCount").remove();
+      $("#dataPane").append(html);
+    }
+
+    const showLayer = (layer_name, show_layer) => {
+      if (!show_layer) {
+        map.setLayoutProperty(layer_name, "visibility", "none");
+      } else {
+        map.setLayoutProperty(layer_name, "visibility", "visible");
+      }
+    };
+
+    function getPaint(features) {
+      let breaks = jenksBreaks(features);
+
+      return [
+        "interpolate",
+        ["linear"],
+        ["number", ["get", "current_count"]],
+        breaks[0][0] - 1,
+        "#ffeda0",
+        breaks[1][0] - 1,
+        "#fed976",
+        breaks[2][0] - 1,
+        "#fd8d3c",
+        breaks[3][0] - 1,
+        "#e31a1c",
+        breaks[4][0],
+        "#800026"
+      ];
+    }
+
+    function postTrips(total_trips, divId = "dataPane") {
+      if (flow == "origin") {
+        var text =
+          formatKs(total_trips) + " trips terminated in the selected area.";
+      } else if (flow == "destination") {
+        var text =
+          formatKs(total_trips) + " trips originated in the selected area.";
+      }
+
+      var html =
+        '<div id="tripAlert" class="alert alert-primary stats" role="alert">' +
+        text +
+        "</div>";
+
+      $("#tripAlert").remove();
+      $("#cellTripCount").remove();
+      $("#" + divId).append(html);
+    }
+
+    function removeStats(selector = "stats") {
+      $("." + selector).remove();
+    }
+
+    function showLoader(divId = "dataPane") {
+      var html = '<p class="loader">Loading...</p>';
+      $("#" + divId).append(html);
+    }
+
+    function hideLoader(divId = "dataPane") {
+      $(".loader").remove();
+    }
+
+    function jenksBreaks(features) {
+      return ckmeans(features.map(f => f.properties.current_count), 5);
+    }
+
+    function setHeight(selector) {
+      var height = $(window).height();
+      $(selector).css("height", height);
+    }
   };
 
-  const showLayer = function(layer_name, show_layer) {
-    if (!show_layer) {
-      map.setLayoutProperty(layer_name, "visibility", "none");
-    } else {
-      map.setLayoutProperty(layer_name, "visibility", "visible");
-    }
+  // All methods declared with `const`, must be "private" and are scoped
+  const registerEventHandlers = () => {
+    console.log("register events");
   };
 
   return docklessMap;
 })();
 
 ATD_DocklessMap.init();
-
-// var API_URL = 'https://dockless-data.austintexas.io/api'
-var API_URL = "http://localhost:8000/v1/trips";
-
-var formatPct = format(".1%");
-var formatKs = format(",");
-
-var total_trips;
-var data;
-var flow;
-var first = true;
-
-mapboxgl.accessToken =
-  "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqbjhkZ25vcjF2eTMzbG52dGRlbnVqOHAifQ.y1xhnHxbB6KlpQgTp1g1Ow";
-
-var mapOptions = {
-  container: "map",
-  style: "mapbox://styles/mapbox/light-v9",
-  center: [-97.74, 30.275],
-  zoom: 13,
-  minZoom: 1,
-  maxZoom: 19
-};
-
-// init map
-var map = new mapboxgl.Map(mapOptions);
-
-// add nav
-var nav = new mapboxgl.NavigationControl();
-
-map.addControl(nav, "top-left");
-
-// add drawing
-var drawOptions = {
-  controls: {
-    trash: false,
-    line_string: false,
-    combine_features: false,
-    uncombine_features: false
-  }
-};
-
-var Draw = new MapboxDraw(drawOptions);
-
-map.addControl(Draw, "top-left");
-
-// do magic
-map.on("load", function() {
-  var url;
-
-  flow = $("#flowSelector option:selected").val();
-
-  $("#flowSelector").change(function() {
-    var previousFlow = flow;
-
-    flow = $("#flowSelector option:selected").val();
-
-    if (map.getLayer("feature_layer")) {
-      var visibility = map.getLayoutProperty("feature_layer", "visibility");
-
-      // if showing feature layer, update layer with new flow
-      if (visibility === "visible") {
-        url = url.replace(previousFlow, flow);
-        showLoader();
-        getData(url);
-        removeStats();
-      }
-    }
-  });
-
-  map.on("draw.create", function(e) {
-    showLoader();
-    url = getUrl(e.features, flow);
-    console.log(url);
-    getData(url);
-    removeStats();
-  });
-
-  map.on("draw.update", function(e) {
-    showLoader();
-    url = getUrl(e.features, flow);
-    getData(url);
-    removeStats();
-  });
-
-  map.on("click", "feature_layer", function(e) {
-    postCellTripCount(e.features[0]);
-  });
-
-  // Change the cursor to a pointer when the mouse is over the states layer.
-  map.on("mouseenter", "feature_layer", function() {
-    map.getCanvas().style.cursor = "pointer";
-  });
-
-  // Change it back to a pointer when it leaves.
-  map.on("mouseleave", "feature_layer", function() {
-    map.getCanvas().style.cursor = "";
-  });
-
-  function getUrl(features, flow) {
-    var coordinates = features[0].geometry.coordinates.toString();
-
-    var url = API_URL + "?xy=" + coordinates + "&flow=" + flow;
-    return url;
-  }
-});
-
-function addFeatures(features, reference_features, total_trips) {
-  if (first) {
-    map.addLayer({
-      id: "feature_layer",
-      type: "fill-extrusion",
-      source: {
-        type: "geojson",
-        data: features
-      },
-      layout: {},
-      paint: {
-        "fill-extrusion-color": getPaint(features.features),
-
-        "fill-extrusion-height": ["*", ["number", ["get", "current_count"]], 1],
-        "fill-extrusion-base": 0,
-        "fill-extrusion-opacity": 0.7
-      }
-    });
-
-    map.addLayer({
-      id: "reference_layer",
-      type: "line",
-      source: {
-        type: "geojson",
-        data: reference_features
-      },
-      layout: {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      paint: {
-        "line-color": "#000",
-        "line-opacity": 0.4,
-        "line-width": 3,
-        "line-dasharray": [3, 3]
-      }
-    });
-
-    showLayer("feature_layer", true);
-    showLayer("reference_layer", true);
-    hideLoader();
-    postTrips(total_trips);
-    first = false;
-  } else {
-    updateLayers(features, reference_features, total_trips);
-  }
-}
-
-function updateLayers(features, reference_features, total_trips) {
-  map.getSource("reference_layer").setData(reference_features);
-  map.getSource("feature_layer").setData(features);
-  map.setPaintProperty(
-    "feature_layer",
-    "fill-extrusion-color",
-    getPaint(features.features)
-  );
-  showLayer("feature_layer", true);
-  showLayer("reference_layer", true);
-  hideLoader();
-  postTrips(total_trips);
-}
-
-function getData(url) {
-  json(url).then(function(json) {
-    Draw.deleteAll();
-    total_trips = json.total_trips;
-    addFeatures(json.features, json.intersect_feature, json.total_trips);
-  });
-}
-
-function postCellTripCount(feature, divId = "dataPane") {
-  var trip_percent = feature.properties.current_count / total_trips;
-
-  if (flow == "origin") {
-    var text =
-      formatKs(feature.properties.current_count) +
-      " (" +
-      formatPct(trip_percent) +
-      ") trips originated in the clicked cell.";
-  } else if (flow == "destination") {
-    var text =
-      formatKs(feature.properties.current_count) +
-      " (" +
-      formatPct(trip_percent) +
-      ") trips terminated in the clicked cell.";
-  }
-
-  var html =
-    '<div id="cellTripCount" class="alert alert-dark stats" role="alert">' +
-    text +
-    "</div>";
-
-  $("#cellTripCount").remove();
-  $("#dataPane").append(html);
-}
-
-// todo, move other showLayer calls into module
-const showLayer = (layer_name, show_layer) => {
-  if (!show_layer) {
-    map.setLayoutProperty(layer_name, "visibility", "none");
-  } else {
-    map.setLayoutProperty(layer_name, "visibility", "visible");
-  }
-};
-
-function getPaint(features) {
-  let breaks = jenksBreaks(features);
-
-  return [
-    "interpolate",
-    ["linear"],
-    ["number", ["get", "current_count"]],
-    breaks[0][0] - 1,
-    "#ffeda0",
-    breaks[1][0] - 1,
-    "#fed976",
-    breaks[2][0] - 1,
-    "#fd8d3c",
-    breaks[3][0] - 1,
-    "#e31a1c",
-    breaks[4][0],
-    "#800026"
-  ];
-}
-
-function postTrips(total_trips, divId = "dataPane") {
-  if (flow == "origin") {
-    var text =
-      formatKs(total_trips) + " trips terminated in the selected area.";
-  } else if (flow == "destination") {
-    var text =
-      formatKs(total_trips) + " trips originated in the selected area.";
-  }
-
-  var html =
-    '<div id="tripAlert" class="alert alert-primary stats" role="alert">' +
-    text +
-    "</div>";
-
-  $("#tripAlert").remove();
-  $("#cellTripCount").remove();
-  $("#" + divId).append(html);
-}
-
-function removeStats(selector = "stats") {
-  $("." + selector).remove();
-}
-
-function showLoader(divId = "dataPane") {
-  var html = '<p class="loader">Loading...</p>';
-  $("#" + divId).append(html);
-}
-
-function hideLoader(divId = "dataPane") {
-  $(".loader").remove();
-}
-
-function jenksBreaks(features) {
-  return ckmeans(features.map(f => f.properties.current_count), 5);
-}

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,26 @@ import { ckmeans } from "simple-statistics";
 import "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css";
 import "./style.css";
 
-setHeight("#map-container");
+var map = {
+  init: function() {
+    console.log("initializing");
+    this.options = {
+      test: "mapfoo"
+    };
+    this.$ui = $("#js");
+    this.registerEventHandlers();
+    this.setHeight("#map-container");
+  },
+  registerEventHandlers: function() {
+    console.log("register events");
+  },
+  setHeight: function(selector) {
+    var height = $(window).height();
+    $(selector).css("height", height);
+  }
+};
+
+map.init();
 
 // var API_URL = 'https://dockless-data.austintexas.io/api'
 var API_URL = "http://localhost:8000/v1/trips";
@@ -284,9 +303,4 @@ function hideLoader(divId = "dataPane") {
 
 function jenksBreaks(features) {
   return ckmeans(features.map(f => f.properties.current_count), 5);
-}
-
-function setHeight(selector) {
-  var height = $(window).height();
-  $(selector).css("height", height);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,16 +12,26 @@ import "./style.css";
 // Locally Scoped Object Module Pattern
 // more info: https://toddmotto.com/mastering-the-module-pattern/#locally-scoped-object-literal
 const ATD_DocklessMap = (function() {
-  // Let this empty object be the placeholder to attach public methods.
-  let docklessMap = {};
-
-  docklessMap.mapOptions = {
-    container: "map",
-    style: "mapbox://styles/mapbox/light-v9",
-    center: [-97.74, 30.275],
-    zoom: 13,
-    minZoom: 1,
-    maxZoom: 19
+  // Let this object be place to store app level state variables and the placeholder to attach public methods.
+  let docklessMap = {
+    map: "",
+    mapOptions: {
+      container: "map",
+      style: "mapbox://styles/mapbox/light-v9",
+      center: [-97.74, 30.275],
+      zoom: 13,
+      minZoom: 1,
+      maxZoom: 19
+    },
+    Draw: "",
+    flow: "",
+    url: "",
+    API_URL: "http://localhost:8000/v1/trips",
+    total_trips: "",
+    first: true,
+    formatPct: format(".1%"),
+    formatKs: format(",")
+    // data: ""
   };
 
   // Attach public methods like this using object literal notation.
@@ -36,7 +46,6 @@ const ATD_DocklessMap = (function() {
   };
 
   const initalizeMap = () => {
-    docklessMap.API_URL = "http://localhost:8000/v1/trips";
     mapboxgl.accessToken =
       "pk.eyJ1Ijoiam9obmNsYXJ5IiwiYSI6ImNqbjhkZ25vcjF2eTMzbG52dGRlbnVqOHAifQ.y1xhnHxbB6KlpQgTp1g1Ow";
     docklessMap.map = new mapboxgl.Map(docklessMap.mapOptions);
@@ -58,56 +67,55 @@ const ATD_DocklessMap = (function() {
     docklessMap.map.addControl(docklessMap.Draw, "top-left");
   };
 
+  const handleFlowSelect = () => {
+    $("#flowSelector").change(function() {
+      var previousFlow = docklessMap.flow;
+
+      docklessMap.flow = $("#flowSelector option:selected").val();
+
+      if (docklessMap.map.getLayer("feature_layer")) {
+        var visibility = docklessMap.map.getLayoutProperty(
+          "feature_layer",
+          "visibility"
+        );
+
+        // if showing feature layer, update layer with new flow
+        if (visibility === "visible") {
+          docklessMap.url = docklessMap.url.replace(
+            previousFlow,
+            docklessMap.flow
+          );
+          showLoader();
+          getData(docklessMap.url);
+          removeStats();
+        }
+      }
+    });
+  };
+
   // TODO: Break this down into smaller pieces
   const runAppCode = () => {
-    var formatPct = format(".1%");
-    var formatKs = format(",");
-
-    var total_trips;
     var data;
-    var flow;
-    var first = true;
 
     // do magic
     docklessMap.map.on("load", function() {
       console.log("do magic");
-      var url;
+      docklessMap.flow = $("#flowSelector option:selected").val();
 
-      flow = $("#flowSelector option:selected").val();
-
-      $("#flowSelector").change(function() {
-        var previousFlow = flow;
-
-        flow = $("#flowSelector option:selected").val();
-
-        if (docklessMap.map.getLayer("feature_layer")) {
-          var visibility = docklessMap.map.getLayoutProperty(
-            "feature_layer",
-            "visibility"
-          );
-
-          // if showing feature layer, update layer with new flow
-          if (visibility === "visible") {
-            url = url.replace(previousFlow, flow);
-            showLoader();
-            getData(url);
-            removeStats();
-          }
-        }
-      });
+      handleFlowSelect();
 
       docklessMap.map.on("draw.create", function(e) {
         showLoader();
-        url = getUrl(e.features, flow);
-        console.log(url);
-        getData(url);
+        docklessMap.url = getUrl(e.features, docklessMap.flow);
+        console.log(docklessMap.url);
+        getData(docklessMap.url);
         removeStats();
       });
 
       docklessMap.map.on("draw.update", function(e) {
         showLoader();
-        url = getUrl(e.features, flow);
-        getData(url);
+        docklessMap.url = getUrl(e.features, docklessMap.flow);
+        getData(docklessMap.url);
         removeStats();
       });
 
@@ -124,103 +132,30 @@ const ATD_DocklessMap = (function() {
       docklessMap.map.on("mouseleave", "feature_layer", function() {
         docklessMap.map.getCanvas().style.cursor = "";
       });
-
-      function getUrl(features, flow) {
-        var coordinates = features[0].geometry.coordinates.toString();
-
-        var url = docklessMap.API_URL + "?xy=" + coordinates + "&flow=" + flow;
-        return url;
-      }
     });
 
-    function addFeatures(features, reference_features, total_trips) {
-      if (first) {
-        docklessMap.map.addLayer({
-          id: "feature_layer",
-          type: "fill-extrusion",
-          source: {
-            type: "geojson",
-            data: features
-          },
-          layout: {},
-          paint: {
-            "fill-extrusion-color": getPaint(features.features),
+    function getUrl(features, flow) {
+      var coordinates = features[0].geometry.coordinates.toString();
 
-            "fill-extrusion-height": [
-              "*",
-              ["number", ["get", "current_count"]],
-              1
-            ],
-            "fill-extrusion-base": 0,
-            "fill-extrusion-opacity": 0.7
-          }
-        });
-
-        docklessMap.map.addLayer({
-          id: "reference_layer",
-          type: "line",
-          source: {
-            type: "geojson",
-            data: reference_features
-          },
-          layout: {
-            "line-cap": "round",
-            "line-join": "round"
-          },
-          paint: {
-            "line-color": "#000",
-            "line-opacity": 0.4,
-            "line-width": 3,
-            "line-dasharray": [3, 3]
-          }
-        });
-
-        showLayer("feature_layer", true);
-        showLayer("reference_layer", true);
-        hideLoader();
-        postTrips(total_trips);
-        first = false;
-      } else {
-        updateLayers(features, reference_features, total_trips);
-      }
-    }
-
-    function updateLayers(features, reference_features, total_trips) {
-      docklessMap.map.getSource("reference_layer").setData(reference_features);
-      docklessMap.map.getSource("feature_layer").setData(features);
-      docklessMap.map.setPaintProperty(
-        "feature_layer",
-        "fill-extrusion-color",
-        getPaint(features.features)
-      );
-      showLayer("feature_layer", true);
-      showLayer("reference_layer", true);
-      hideLoader();
-      postTrips(total_trips);
-    }
-
-    function getData(url) {
-      json(url).then(function(json) {
-        docklessMap.Draw.deleteAll();
-        total_trips = json.total_trips;
-        addFeatures(json.features, json.intersect_feature, json.total_trips);
-      });
+      var url = docklessMap.API_URL + "?xy=" + coordinates + "&flow=" + flow;
+      return url;
     }
 
     function postCellTripCount(feature, divId = "dataPane") {
-      var trip_percent = feature.properties.current_count / total_trips;
+      var trip_percent =
+        feature.properties.current_count / docklessMap.total_trips;
 
-      if (flow == "origin") {
+      if (docklessMap.flow == "origin") {
         var text =
-          formatKs(feature.properties.current_count) +
+          docklessMap.formatKs(feature.properties.current_count) +
           " (" +
-          formatPct(trip_percent) +
+          docklessMap.formatPct(trip_percent) +
           ") trips originated in the clicked cell.";
-      } else if (flow == "destination") {
+      } else if (docklessMap.flow == "destination") {
         var text =
-          formatKs(feature.properties.current_count) +
+          docklessMap.formatKs(feature.properties.current_count) +
           " (" +
-          formatPct(trip_percent) +
+          docklessMap.formatPct(trip_percent) +
           ") trips terminated in the clicked cell.";
       }
 
@@ -240,64 +175,29 @@ const ATD_DocklessMap = (function() {
         docklessMap.map.setLayoutProperty(layer_name, "visibility", "visible");
       }
     };
-
-    function getPaint(features) {
-      let breaks = jenksBreaks(features);
-
-      return [
-        "interpolate",
-        ["linear"],
-        ["number", ["get", "current_count"]],
-        breaks[0][0] - 1,
-        "#ffeda0",
-        breaks[1][0] - 1,
-        "#fed976",
-        breaks[2][0] - 1,
-        "#fd8d3c",
-        breaks[3][0] - 1,
-        "#e31a1c",
-        breaks[4][0],
-        "#800026"
-      ];
-    }
-
-    function postTrips(total_trips, divId = "dataPane") {
-      if (flow == "origin") {
-        var text =
-          formatKs(total_trips) + " trips terminated in the selected area.";
-      } else if (flow == "destination") {
-        var text =
-          formatKs(total_trips) + " trips originated in the selected area.";
-      }
-
-      var html =
-        '<div id="tripAlert" class="alert alert-primary stats" role="alert">' +
-        text +
-        "</div>";
-
-      $("#tripAlert").remove();
-      $("#cellTripCount").remove();
-      $("#" + divId).append(html);
-    }
-
-    function showLoader(divId = "dataPane") {
-      var html = '<p class="loader">Loading...</p>';
-      $("#" + divId).append(html);
-    }
-
-    function hideLoader(divId = "dataPane") {
-      $(".loader").remove();
-    }
-
-    function jenksBreaks(features) {
-      return ckmeans(features.map(f => f.properties.current_count), 5);
-    }
   };
 
   // All methods declared with `const`, must be "private" and are scoped
   const registerEventHandlers = () => {
     console.log("registering events");
     clearMapOnEscEvent();
+  };
+
+  const showLoader = (divId = "dataPane") => {
+    var html = '<p class="loader">Loading...</p>';
+    $("#" + divId).append(html);
+  };
+
+  const hideLoader = (divId = "dataPane") => {
+    $(".loader").remove();
+  };
+
+  const getData = url => {
+    json(url).then(function(json) {
+      docklessMap.Draw.deleteAll();
+      docklessMap.total_trips = json.total_trips;
+      addFeatures(json.features, json.intersect_feature, json.total_trips);
+    });
   };
 
   const setHeight = selector => {
@@ -323,8 +223,119 @@ const ATD_DocklessMap = (function() {
     }
   };
 
+  const updateLayers = (features, reference_features, total_trips) => {
+    docklessMap.map.getSource("reference_layer").setData(reference_features);
+    docklessMap.map.getSource("feature_layer").setData(features);
+    docklessMap.map.setPaintProperty(
+      "feature_layer",
+      "fill-extrusion-color",
+      getPaint(features.features)
+    );
+    showLayer("feature_layer", true);
+    showLayer("reference_layer", true);
+    hideLoader();
+    postTrips(total_trips);
+  };
+
   const removeStats = (selector = "stats") => {
     $("." + selector).remove();
+  };
+
+  const addFeatures = (features, reference_features, total_trips) => {
+    if (docklessMap.first) {
+      docklessMap.map.addLayer({
+        id: "feature_layer",
+        type: "fill-extrusion",
+        source: {
+          type: "geojson",
+          data: features
+        },
+        layout: {},
+        paint: {
+          "fill-extrusion-color": getPaint(features.features),
+
+          "fill-extrusion-height": [
+            "*",
+            ["number", ["get", "current_count"]],
+            1
+          ],
+          "fill-extrusion-base": 0,
+          "fill-extrusion-opacity": 0.7
+        }
+      });
+
+      docklessMap.map.addLayer({
+        id: "reference_layer",
+        type: "line",
+        source: {
+          type: "geojson",
+          data: reference_features
+        },
+        layout: {
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        paint: {
+          "line-color": "#000",
+          "line-opacity": 0.4,
+          "line-width": 3,
+          "line-dasharray": [3, 3]
+        }
+      });
+
+      showLayer("feature_layer", true);
+      showLayer("reference_layer", true);
+      hideLoader();
+      postTrips(docklessMap.total_trips);
+      docklessMap.first = false;
+    } else {
+      updateLayers(features, reference_features, docklessMap.total_trips);
+    }
+  };
+
+  const getPaint = features => {
+    let breaks = jenksBreaks(features);
+
+    return [
+      "interpolate",
+      ["linear"],
+      ["number", ["get", "current_count"]],
+      breaks[0][0] - 1,
+      "#ffeda0",
+      breaks[1][0] - 1,
+      "#fed976",
+      breaks[2][0] - 1,
+      "#fd8d3c",
+      breaks[3][0] - 1,
+      "#e31a1c",
+      breaks[4][0],
+      "#800026"
+    ];
+  };
+
+  const jenksBreaks = features => {
+    return ckmeans(features.map(f => f.properties.current_count), 5);
+  };
+
+  const postTrips = (total_trips, divId = "dataPane") => {
+    if (docklessMap.flow == "origin") {
+      var text =
+        docklessMap.formatKs(total_trips) +
+        " trips terminated in the selected area.";
+    } else if (docklessMap.flow == "destination") {
+      var text =
+        docklessMap.formatKs(total_trips) +
+        " trips originated in the selected area.";
+    }
+
+    var html =
+      '<div id="tripAlert" class="alert alert-primary stats" role="alert">' +
+      text +
+      "</div>";
+
+    $("#tripAlert").remove();
+    $("#cellTripCount").remove();
+    $("#" + divId).append(html);
   };
 
   return docklessMap;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,9 +10,6 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin(["dist"]),
-    new HtmlWebpackPlugin({
-      template: "src/index.html"
-    }),
     new webpack.HotModuleReplacementPlugin()
   ],
   devServer: {
@@ -47,3 +44,11 @@ module.exports = {
     ]
   }
 };
+
+if (process.env.NODE_ENV !== "production") {
+  module.exports.plugins = (module.exports.plugins || []).concat([
+    new HtmlWebpackPlugin({
+      template: "src/index.html"
+    })
+  ]);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,24 +1,24 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-const CleanWebpackPlugin = require('clean-webpack-plugin');
-const webpack = require('webpack');
+const CleanWebpackPlugin = require("clean-webpack-plugin");
+const webpack = require("webpack");
 
 module.exports = {
   mode: "development",
   entry: {
-    app: "./src/index.js",
+    app: "./src/index.js"
   },
   plugins: [
-    new CleanWebpackPlugin(['dist']),
+    new CleanWebpackPlugin(["dist"]),
     new HtmlWebpackPlugin({
-      template: 'src/index.html'
+      template: "src/index.html"
     }),
     new webpack.HotModuleReplacementPlugin()
   ],
-   devServer: {
-    contentBase: './dist',
+  devServer: {
+    contentBase: "./dist",
     hot: true
-   },
+  },
   devtool: "inline-source-map",
   output: {
     filename: "[name].bundle.js",
@@ -33,6 +33,16 @@ module.exports = {
       {
         test: /\.(png|svg|jpg|gif)$/,
         use: ["file-loader"]
+      },
+      {
+        test: /\.m?js$/,
+        exclude: /(node_modules|bower_components)/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
Doing a few things in this PR...

- add babel so we can write modern javascript and backfill for older browsers using the webpack plugin [babel-loader](https://github.com/babel/babel-loader) [Relates to #10] 
- add mode select (bike/scooter/both) to the form. Still need to add functionality on the JS side. [Closes #12]
- reorganize the javascript to be a little more encapsulated using the [Locally Scoped Object Module Pattern](https://toddmotto.com/mastering-the-module-pattern/#locally-scoped-object-literal).
