### PR TITLE
Netlify deploy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 // import _ from "lodash"; // not using this right now but maybe we will
-import $ from "jQuery";
+import $ from "jquery";
 import mapboxgl from "mapbox-gl";
 import MapboxDraw from "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw";
 import { format } from "d3-format";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,10 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin(["dist"]),
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.HotModuleReplacementPlugin(),
+    new HtmlWebpackPlugin({
+      template: "./src/index.html"
+    })
   ],
   devServer: {
     contentBase: "./dist",
@@ -48,7 +51,7 @@ module.exports = {
 if (process.env.NODE_ENV !== "production") {
   module.exports.plugins = (module.exports.plugins || []).concat([
     new HtmlWebpackPlugin({
-      template: "src/index.html"
+      template: "./src/index.html"
     })
   ]);
 }


### PR DESCRIPTION
Closes #6 

https://deploy-preview-21--dockless.netlify.com/

Front end deploying via Netlify but the current `API_URL` config in index.js is pointing at localhost so it only works if you have the Sanic app running at localhost:8000.