### PR TITLE
Error messaging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6365,10 +6365,10 @@
         "is-object": "^1.0.1"
       }
     },
-    "jquery-slim": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jquery-slim/-/jquery-slim-3.0.0.tgz",
-      "integrity": "sha1-h6svoQUBeY6TEkpLXrlTyFN5cH4="
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "js-levenshtein": {
       "version": "1.1.4",
@@ -8121,6 +8121,11 @@
           }
         }
       }
+    },
+    "popper.js": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.5.tgz",
+      "integrity": "sha512-fs4Sd8bZLgEzrk8aS7Em1qh+wcawtE87kRUJQhK6+LndyV1HerX7+LURzAylVaTyWIn5NTB/lyjnWqw/AZ6Yrw=="
     },
     "portfinder": {
       "version": "1.0.19",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
     "@mapbox/mapbox-gl-draw": "^1.0.9",
     "bootstrap": "^4.1.3",
     "d3": "^5.7.0",
-    "jquery-slim": "^3.0.0",
+    "jquery": "^3.3.1",
     "lodash": "^4.17.11",
     "mapbox-gl": "^0.50.0",
+    "popper.js": "^1.14.5",
     "simple-statistics": "^6.1.1"
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -99,6 +99,25 @@
           </div>
         </div>
       </div>
+
+      <!-- Modal -->
+      <div class="modal fade" id="errorModal" tabindex="-1" role="dialog" aria-labelledby="errorModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="errorModalLabel">Server Error</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -240,7 +240,7 @@ const ATD_DocklessMap = (function() {
   };
 
   const getData = url => {
-    json(url, { mode: "no-cors" })
+    json(url)
       .then(json => {
         docklessMap.Draw.deleteAll();
         docklessMap.total_trips = json.total_trips;

--- a/src/index.js
+++ b/src/index.js
@@ -250,7 +250,7 @@ const ATD_DocklessMap = (function() {
         $("#errorModal").modal("show");
         $("#errorModal .modal-body").html(`
           <p>It seems that we're having trouble getting data from our server at this point in time.</p>
-          <p>Please try to refresh this page and try again.</p>
+          <p>Please refresh this page and try again.</p>
           <p>If the problem persists, please <a href="mailto:ATDDataTechnologyServices@austintexas.gov?subject=Bug Report: Dockless Data Explorer">email us</a> or <a href="https://github.com/cityofaustin/dockless/issues/new">create a new issue</a> on our Github repo.</p>
           <h5>Error Message:</h5><code>${error}</code>
         `);

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import $ from "jquery-slim";
+import "jquery";
+import "bootstrap/dist/js/bootstrap";
 import mapboxgl from "mapbox-gl";
 import MapboxDraw from "@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw";
 import { format } from "d3-format";

--- a/src/index.js
+++ b/src/index.js
@@ -240,11 +240,21 @@ const ATD_DocklessMap = (function() {
   };
 
   const getData = url => {
-    json(url, { mode: "cors" }).then(function(json) {
-      docklessMap.Draw.deleteAll();
-      docklessMap.total_trips = json.total_trips;
-      addFeatures(json.features, json.intersect_feature, json.total_trips);
-    });
+    json(url, { mode: "no-cors" })
+      .then(json => {
+        docklessMap.Draw.deleteAll();
+        docklessMap.total_trips = json.total_trips;
+        addFeatures(json.features, json.intersect_feature, json.total_trips);
+      })
+      .catch(error => {
+        $("#errorModal").modal("show");
+        $("#errorModal .modal-body").html(`
+          <p>It seems that we're having trouble getting data from our server at this point in time.</p>
+          <p>Please try to refresh this page and try again.</p>
+          <p>If the problem persists, please <a href="mailto:ATDDataTechnologyServices@austintexas.gov?subject=Bug Report: Dockless Data Explorer">email us</a> or <a href="https://github.com/cityofaustin/dockless/issues/new">create a new issue</a> on our Github repo.</p>
+          <h5>Error Message:</h5><code>${error}</code>
+        `);
+      });
   };
 
   const setHeight = selector => {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 
@@ -11,6 +12,12 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: "./src/index.html",
       minify: "true"
+    }),
+    new webpack.ProvidePlugin({
+      $: "jquery",
+      jQuery: "jquery",
+      "window.jQuery": "jquery",
+      Popper: ["popper.js", "default"]
     })
   ],
   output: {


### PR DESCRIPTION
Closes #5 

It seems like the simplest thing to do is watch for errors via a catch function chained to the promise in the `getData` method. When it catches an error, we pop a basic Bootstrap.js modal with some error messaging and dump the raw error code in case it helps.

I don't like that bootstrap.js needs to be added for this small thing, and that it requires popper.js and jquery instead of jquery-slim. But for now, it seemed like the simplest path.

![nov-08-2018 13-03-34](https://user-images.githubusercontent.com/5697474/48221322-628f0480-e357-11e8-892a-fcbe98999e18.gif)
