### PR TITLE
Fix legend bug #78

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -379,6 +379,7 @@ const ATD_DocklessMap = (function() {
         }
         docklessMap.total_trips = total_trips;
         addFeatures(features, intersect_feature, total_trips);
+        updateLegend(features.features);
       })
       .catch(error => {
         $("#errorModal").modal("show");
@@ -439,7 +440,6 @@ const ATD_DocklessMap = (function() {
       "fill-extrusion-color",
       getPaint(features.features)
     );
-    updateLegend(features.features);
     showLayer("feature_layer", true);
     showLayer("reference_layer", true);
     hideLoader();
@@ -449,6 +449,9 @@ const ATD_DocklessMap = (function() {
   const updateLegend = features => {
     const counts = features.map(f => f.properties.trips);
     const breaks = jenksBreaks(counts, docklessMap.numClasses);
+
+    // Reset & remove old legend HTML content
+    $("#js-legend").empty();
 
     // Add legend title
     $("#js-legend").append("<span class='legend-title'>Number of Trips</span>");
@@ -552,7 +555,6 @@ const ATD_DocklessMap = (function() {
         }
       });
 
-      updateLegend(features.features);
       showLayer("feature_layer", true);
       showLayer("reference_layer", true);
       showLayer("feature_layer_highlight", false);


### PR DESCRIPTION
Fixes #78 

I did two things here:
1. Add a jQuery line that empties the legend of its content before adding any new content. This should prevent us from seeing the multiple legend in any other context.
2. `updateLegend()` was being called in two different scenarios for when we (1) `updateLayers()` and (2)`addFeatures()`. Instead of having it called inside those two functions, it now only gets called within `getData()` function. This ties the logic of updating the legend to data fetching (which is more consistent) instead of map features (which happens in different ways depending on the state of the app).